### PR TITLE
Use abspath for Linux compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from dateutil.parser import parse
 from timezones import whois_timezone_info
 
 # Global Constants
-directory = path.dirname(__file__)
+directory = path.dirname(path.abspath(__file__))
 tmpFilePath = directory + "/tmpFile.txt"
 promptsPath = directory + "/prompts.json"
 settingsPath = directory + "/settings.json"


### PR DESCRIPTION
path.dirname() returns empty string on Linux systems. Use path.abspath() instead for Linux compatibility and better practice.